### PR TITLE
Update TransparentUpgradeableProxy.sol

### DIFF
--- a/contracts/transparent_proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/transparent_proxy/TransparentUpgradeableProxy.sol
@@ -31,7 +31,7 @@ contract TransparentUpgradeableProxy is ERC1967Proxy {
      * optionally initialized with `_data` as explained in {ERC1967Proxy-constructor}.
      */
     constructor(address _logic, address admin_, bytes memory _data) payable ERC1967Proxy(_logic, _data) {
-        assert(_ADMIN_SLOT == bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
+        assert(_ADMIN_SLOT == 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103);
         _changeAdmin(admin_);
     }
 


### PR DESCRIPTION
Compute bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1) off-chain to avoid consuming extra gas while calculating the immutable results.